### PR TITLE
Fix null value handling

### DIFF
--- a/.changeset/happy-actors-guess.md
+++ b/.changeset/happy-actors-guess.md
@@ -1,0 +1,5 @@
+---
+"@pbinj/pbj": patch
+---
+
+small bug fix in handling null values

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ dist
 **/dist
 **/node_modules
 .env.*
+.idea

--- a/packages/pbj/src/__test__/context.test.ts
+++ b/packages/pbj/src/__test__/context.test.ts
@@ -398,4 +398,12 @@ describe("proxy", () => {
       expect(b).toBe(1);
     });
   });
+  describe("null", ()=>{
+    it("should not blow up if a value is null", ()=>{
+      const ctx = createNewContext();
+      const factory = () => null as any;
+      const a = ctx.register(pbjKey<{ a: number }>("test-factory-a"), factory);
+      expect(a.invoke()).toBe(null);
+    });
+  })
 });

--- a/packages/pbj/src/__test__/context.test.ts
+++ b/packages/pbj/src/__test__/context.test.ts
@@ -398,12 +398,12 @@ describe("proxy", () => {
       expect(b).toBe(1);
     });
   });
-  describe("null", ()=>{
-    it("should not blow up if a value is null", ()=>{
+  describe("null", () => {
+    it("should not blow up if a value is null", () => {
       const ctx = createNewContext();
       const factory = () => null as any;
       const a = ctx.register(pbjKey<{ a: number }>("test-factory-a"), factory);
       expect(a.invoke()).toBe(null);
     });
-  })
+  });
 });

--- a/packages/pbj/src/newProxy.ts
+++ b/packages/pbj/src/newProxy.ts
@@ -1,5 +1,11 @@
 import { nullableSymbol } from "./guards.js";
-import {has as _has, hasA, type Constructor, type Fn, isObjectish} from "@pbinj/pbj-guards";
+import {
+  has as _has,
+  hasA,
+  type Constructor,
+  type Fn,
+  isObjectish,
+} from "@pbinj/pbj-guards";
 import { proxyKey, serviceDescriptorKey, serviceSymbol } from "./symbols.js";
 import type { ServiceDescriptorI } from "./types.js";
 
@@ -71,7 +77,7 @@ export function newProxy<T extends Constructor>(
       if (service.primitive) {
         return false;
       }
-      return isObjectish(val) ? (prop in val) : false;
+      return isObjectish(val) ? prop in val : false;
     },
     getPrototypeOf() {
       return Object.getPrototypeOf(service.invoke());

--- a/packages/pbj/src/newProxy.ts
+++ b/packages/pbj/src/newProxy.ts
@@ -1,5 +1,5 @@
 import { nullableSymbol } from "./guards.js";
-import { has, hasA, type Constructor, type Fn } from "@pbinj/pbj-guards";
+import {has as _has, hasA, type Constructor, type Fn, isObjectish} from "@pbinj/pbj-guards";
 import { proxyKey, serviceDescriptorKey, serviceSymbol } from "./symbols.js";
 import type { ServiceDescriptorI } from "./types.js";
 
@@ -64,15 +64,14 @@ export function newProxy<T extends Constructor>(
       if (service.primitive) {
         return [];
       }
-      const keys = Reflect.ownKeys(value);
-      return keys;
+      return Reflect.ownKeys(value);
     },
     has(_target, prop) {
       const val = service.invoke();
       if (service.primitive) {
         return false;
       }
-      return prop in val;
+      return isObjectish(val) ? (prop in val) : false;
     },
     getPrototypeOf() {
       return Object.getPrototypeOf(service.invoke());
@@ -83,7 +82,7 @@ export function newProxy<T extends Constructor>(
 function isServiceDescriptor<T extends Fn | Constructor | unknown>(
   v: unknown,
 ): v is ServiceDescriptorI<any, T> {
-  return has(v, serviceSymbol);
+  return _has(v, serviceSymbol);
 }
 
 export const serviceDescriptor = <T extends Fn | Constructor | unknown>(


### PR DESCRIPTION
This PR addresses a bug in handling null values in the PBJ library.

Changes:
- Fixed issue with null value handling

This is a patch release that improves reliability when working with null values.